### PR TITLE
Annotation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,7 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
+  push
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,11 @@
 name: Test
 
 on:
-  push
+  push:
+    branches: '**'
+    paths:
+      - 'madtypes/__init__.py'
+      - 'tests/test_schema.py'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ assert schema(Basket) == {
 ### 🔥 Annotation attributes
 It is possible to use the `Annotation` metaclass to add type-check to a class definition.
 
-```
+```python
 class SomeStringAttribute(str, metaclass=Annotation):
-   ...
+   pass
 
 SomeDescriptedAttribute(2) # raise type error
 ```
 
 It is possible to use this to further describe a field.
 
-```
+```python
 class SomeDescriptedAttribute(str, metaclass=Annotation):
     annotation = str
     description = "Some description"
@@ -91,7 +91,7 @@ class SomeDescriptedAttribute(str, metaclass=Annotation):
 
 Now when we use `schema` on `SomeDescription` to generate the json-schema, it will use include the description attribute
 
-```
+```python
 class DescriptedString(str, metaclass=Annotation):
     description = "Some description"
     annotation = str

--- a/README.md
+++ b/README.md
@@ -71,6 +71,47 @@ assert schema(Basket) == {
 }
 ```
 
+### 🔥 Annotation attributes
+It is possible to use the `Annotation` metaclass to add type-check to a class definition.
+
+```
+class SomeStringAttribute(str, metaclass=Annotation):
+   ...
+
+SomeDescriptedAttribute(2) # raise type error
+```
+
+It is possible to use this to further describe a field.
+
+```
+class SomeDescriptedAttribute(str, metaclass=Annotation):
+    annotation = str
+    description = "Some description"
+```
+
+Now when we use `schema` on `SomeDescription` to generate the json-schema, it will use include the description attribute
+
+```
+class DescriptedString(str, metaclass=Annotation):
+    description = "Some description"
+    annotation = str
+
+class DescriptedItem(Schema):
+    descripted: DescriptedString
+
+assert schema(DescriptedItem) == {
+    "type": "object",
+    "properties": {
+        "descripted": {
+            "type": "string",
+            "description": "Some description",
+        },
+    },
+    "required": ["descripted"],
+}
+
+```
+
 
 [![Test](https://github.com/6r17/madtypes/actions/workflows/test.yaml/badge.svg)](./tests/test_schema.py)
 [![pypi](https://img.shields.io/pypi/v/madtypes)](https://pypi.org/project/madtypes/)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ class SomeDescriptedAttribute(str, metaclass=Annotation):
     description = "Some description"
 ```
 
-Now when we use `schema` on `SomeDescription` to generate the json-schema, it will use include the description attribute
+Now when we use `schema` on `SomeDescription` to generate the json-schema, it will include the description attribute
 
 ```python
 class DescriptedString(str, metaclass=Annotation):

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -1,4 +1,4 @@
-from typing import get_args, get_origin, Union, Type, get_type_hints
+from typing import get_args, get_origin, Union, Type
 import inspect
 
 TYPE_TO_STRING: dict[type, str] = {
@@ -36,7 +36,6 @@ class Annotation(type):
 
         # Override the __new__ method of the list class
         def new_method(cls, values):
-            print(cls, values, annotation)
             # Check the type of each value before initializing the list
             if not is_value_compatible_with_annotation(values, annotation):
                 raise TypeError(
@@ -141,16 +140,12 @@ def schema(
             required = origin.required_fields()
             if len(required) > 0:
                 result.update({"required": required})
-        if issubclass(origin, Annotation):
+        if getattr(origin, "annotation", False):
             extra = {
                 key: value
                 for key, value in origin.__dict__.items()
                 if not callable(value) and not key.startswith("__")
             }
-            try:
-                del extra["annotation"]
-            except KeyError:
-                pass
             return schema(origin.annotation, **extra)
     if is_optional_type(annotation):
         return schema(remove_optional(annotation))

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -35,15 +35,16 @@ class Annotation(type):
         annotation = attrs.get("annotation")
 
         # Override the __new__ method of the list class
-        def new_method(cls, values):
+        def new_method(cls, *values, **kwargs):
             # Check the type of each value before initializing the list
-            if not is_value_compatible_with_annotation(values, annotation):
-                raise TypeError(
-                    f"All values must be compatible with the annotation '{annotation}'"
-                )
+            for value in values:
+                if not is_value_compatible_with_annotation(value, annotation):
+                    raise TypeError(
+                        f"All values must be compatible with the annotation '{annotation}'"
+                    )
 
             # Create the list instance and initialize it with the values
-            instance = super(cls, cls).__new__(cls, values)
+            instance = super(cls, cls).__new__(cls, *values, **kwargs)
             return instance
 
         # Assign the overridden __new__ method to the class

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="madtypes",
-    version="0.0.3",
+    version="0.0.4",
     author="6r17",
     author_email="patrick.borowy@proton.me",
     description="Python typing that raise TypeError at runtime",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -439,11 +439,14 @@ def test_descripted_list_value_set():
     a = SomeListItem(names=SomeDescriptedListField(["1", "2", "3"]))
     assert len(a.names) == 3
     assert json.dumps(a) == '{"names": ["1", "2", "3"]}'
+    with pytest.raises(AttributeError):  # append does not exist
+        a.append("foo")
 
 
-def notest_descripted_json_schema():
-    class DescriptedString(str, Annotation):
+def test_descripted_json_schema():
+    class DescriptedString(str, metaclass=Annotation):
         description = "Some description"
+        annotation = str
 
     class DescriptedItem(Schema):
         descripted: DescriptedString

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -443,6 +443,19 @@ def test_descripted_list_value_set():
         a.append("foo")
 
 
+def test_descripted_list_object_value_set():
+    class Foo(Schema):
+        name: str
+
+    class DescriptedFoo(Foo, metaclass=Annotation):
+        description = "description"
+        annotation = Foo
+
+    DescriptedFoo(name="foo")
+    with pytest.raises(TypeError):
+        DescriptedFoo(name=2)
+
+
 def test_descripted_json_schema():
     class DescriptedString(str, metaclass=Annotation):
         description = "Some description"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 from typing import Optional
 from madtypes import schema, Schema, Annotation, Immutable
 import pytest
+import json
 
 
 class Gender(Schema):
@@ -66,22 +67,22 @@ def test_set():
         a.gender.male = "foo"
 
 
-def test_int():
+def test_int_schema():
     assert schema(int) == {"type": "integer"}
 
 
-def test_array():
+def test_array_schema():
     assert schema(list[int]) == {"type": "array", "items": {"type": "integer"}}
 
 
-def test_tuple():
+def test_tuple_schema():
     assert schema(tuple[int, int]) == {
         "type": "array",
         "items": [{"type": "integer"}, {"type": "integer"}],
     }
 
 
-def test_object():
+def test_object_schema():
     class Item(Schema):
         name: str
 
@@ -92,7 +93,7 @@ def test_object():
     }
 
 
-def test_array_of_object():
+def test_array_of_object_schema():
     class Item(Schema):
         name: str
 
@@ -117,7 +118,7 @@ def test_array_of_object():
     }
 
 
-def test_tuple_of_object():
+def test_tuple_of_object_schema():
     class Item(Schema):
         name: str
 
@@ -149,7 +150,7 @@ def test_tuple_of_object():
     }
 
 
-def test_json_schema():
+def test_object_with_object_schema():
     print(schema(Item))
     assert schema(Item) == {
         "type": "object",
@@ -165,29 +166,6 @@ def test_json_schema():
             },
         },
         "required": ["name", "gender"],
-    }
-
-
-class DescriptedString(Annotation):
-    description = "Some description"
-    annotation = str
-
-
-class DescriptedItem(Schema):
-    descripted: DescriptedString
-
-
-def test_descripted_json_schema():
-    print(schema(DescriptedItem))
-    assert schema(DescriptedItem) == {
-        "type": "object",
-        "properties": {
-            "descripted": {
-                "type": "string",
-                "description": "Some description",
-            },
-        },
-        "required": ["descripted"],
     }
 
 
@@ -424,4 +402,60 @@ def test_optional_json_schema_with_array():
         "properties": {
             "elements": {"type": "array", "items": {"type": "integer"}}
         },
+    }
+
+
+def test_descripted_value_set():
+    class SomeDescriptedField(str, metaclass=Annotation):
+        description = "foo"
+        annotation = str
+
+    class SomeItem(Schema):
+        name: SomeDescriptedField
+
+    with pytest.raises(TypeError):
+        SomeDescriptedField(2)
+    a = SomeItem(name=SomeDescriptedField("foo"))
+    assert a.name == "foo"
+    a.name = SomeDescriptedField("bar")
+    assert a == {"name": "bar"}
+    assert json.dumps(a) == '{"name": "bar"}'
+    assert a.name.description == "foo"
+
+
+def test_descripted_list_value_set():
+    class SomeDescriptedListField(list, metaclass=Annotation):
+        description = "foo"
+        annotation = list[str]
+
+    class SomeListItem(Schema):
+        names: SomeDescriptedListField
+
+    values = SomeDescriptedListField(["1", "2", "3"])
+    print(values)
+    assert values == ["1", "2", "3"]
+    with pytest.raises(TypeError):
+        SomeListItem(names=SomeDescriptedListField([1]))
+    a = SomeListItem(names=SomeDescriptedListField(["1", "2", "3"]))
+    assert len(a.names) == 3
+    assert json.dumps(a) == '{"names": ["1", "2", "3"]}'
+
+
+def notest_descripted_json_schema():
+    class DescriptedString(str, Annotation):
+        description = "Some description"
+
+    class DescriptedItem(Schema):
+        descripted: DescriptedString
+
+    print(schema(DescriptedItem))
+    assert schema(DescriptedItem) == {
+        "type": "object",
+        "properties": {
+            "descripted": {
+                "type": "string",
+                "description": "Some description",
+            },
+        },
+        "required": ["descripted"],
     }


### PR DESCRIPTION
changes:
- `Annotation` metaclass allows to define additional properties on a typing used with `Schema`
- `Annotation.description is used to further describe the json-schema generated`
- `Annotation` will overwrite the `__new__` method of a class to introduce type-check