### PR TITLE
feat: object validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ b = Foo(age=2, **e) # create a copy with changes
 ### json-schema
   
 ```python
-from madtypes import schema, Schema
+from madtypes import json_schema, Schema
 from typing import Optional
 
 class Item(Schema):
@@ -56,7 +56,7 @@ class Item(Schema):
 class Basket(Schema):
     items: list[Item]
 
-assert schema(Basket) == {
+assert json_schema(Basket) == {
     "type": "object",
     "properties": {
         "items": {
@@ -89,7 +89,7 @@ class SomeDescriptedAttribute(str, metaclass=Annotation):
     description = "Some description"
 ```
 
-Now when we use `schema` on `SomeDescription` to generate the json-schema, it will include the description attribute
+Now when we use `json_schema` on `SomeDescription` to generate the json-schema, it will include the description attribute
 
 ```python
 class DescriptedString(str, metaclass=Annotation):
@@ -99,7 +99,7 @@ class DescriptedString(str, metaclass=Annotation):
 class DescriptedItem(Schema):
     descripted: DescriptedString
 
-assert schema(DescriptedItem) == {
+assert json_schema(DescriptedItem) == {
     "type": "object",
     "properties": {
         "descripted": {
@@ -131,4 +131,4 @@ pip3 install madtypes
 
 - It renders natively to `JSON`, facilitating data serialization and interchange.
 
-- The library also includes a `schema()` function that generates JSON-Schema representations based on class definitions.
+- The library also includes a `json_schema()` function that generates JSON-Schema representations based on class definitions.

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -130,7 +130,7 @@ class Immutable(Schema):
         raise TypeError("'Immutable' object does not support item assignment")
 
 
-def schema(
+def json_schema(
     annotation: Union[Type["Type"], Type["Annotation"], Type["Schema"]],
     **kwargs,
 ) -> dict:
@@ -141,9 +141,9 @@ def schema(
     if origin in TYPE_TO_STRING:
         result.update({"type": TYPE_TO_STRING[origin]})
     if origin == list:
-        result.update({"items": schema(args[0])})
+        result.update({"items": json_schema(args[0])})
     if origin == tuple:
-        result.update({"items": [schema(arg) for arg in args]})
+        result.update({"items": [json_schema(arg) for arg in args]})
     if isinstance(origin, str):
         raise SyntaxError("A typing annotation has been written as Literal")
     if inspect.isclass(origin):
@@ -152,7 +152,7 @@ def schema(
                 {
                     "type": "object",
                     "properties": {
-                        name: schema(field)
+                        name: json_schema(field)
                         for name, field in origin.get_fields()
                     },
                 }
@@ -166,7 +166,7 @@ def schema(
                 for key, value in origin.__dict__.items()
                 if not callable(value) and not key.startswith("__")
             }
-            return schema(origin.annotation, **extra)
+            return json_schema(origin.annotation, **extra)
     if is_optional_type(annotation):
-        return schema(remove_optional(annotation))
+        return json_schema(remove_optional(annotation))
     return result

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -25,29 +25,18 @@ def type_check(value, annotation):
     origin = get_origin(annotation)
     args = get_args(annotation)
 
-    print("origin:", origin)
-    print("args:", args)
-    print("value:", value)
     if origin is None:
         # Non-generic type
         return isinstance(value, annotation)
     elif origin is list or origin is set or origin is Union:
-        print("sub annotation", args)
         # typing.Union cannot be used by is_instance
         if is_optional_type(annotation):
             inner_annotation = args[0]
-            print(
-                ">>",
-                inner_annotation,
-                value,
-                type_check(value, inner_annotation),
-            )
             return type_check(value, inner_annotation)
         elif isinstance(value, origin):
             if args:
                 # Parametrized list annotation
                 inner_annotation = args[0]
-                print(inner_annotation)
                 return all(
                     type_check(item, inner_annotation) for item in value
                 )
@@ -73,7 +62,6 @@ class Annotation(type):
                     )
 
                 if pattern and not re.fullmatch(pattern, value):
-                    print(value)
                     raise TypeError(
                         f"`{values[0]}` did not match provided pattern `{pattern}`"
                     )
@@ -141,6 +129,8 @@ class Immutable(Schema):
     def __setitem__(self, __key__, __value__):
         raise TypeError("'Immutable' object does not support item assignment")
 
+def __adapt_pattern_to_json_schema(pattern):
+    
 
 def json_schema(
     annotation: Union[Type["Type"], Type["Annotation"], Type["Schema"]],

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -76,6 +76,12 @@ class Schema(dict):
                 optional = is_optional_type(value)
                 if not optional:
                     raise TypeError(f"{key} is a mandatory field")
+        if not self.is_valid(**kwargs):
+            raise TypeError(f"{kwargs} did not pass object validation")
+
+    def is_valid(self, **__kwargs__) -> bool:
+        """Validation at Object scope, for validation based on multiple fields."""
+        return True
 
     @classmethod
     def get_fields(cls):

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -129,8 +129,6 @@ class Immutable(Schema):
     def __setitem__(self, __key__, __value__):
         raise TypeError("'Immutable' object does not support item assignment")
 
-def __adapt_pattern_to_json_schema(pattern):
-    
 
 def json_schema(
     annotation: Union[Type["Type"], Type["Annotation"], Type["Schema"]],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="madtypes",
-    version="0.0.4",
+    version="0.0.5",
     author="6r17",
     author_email="patrick.borowy@proton.me",
     description="Python typing that raise TypeError at runtime",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from madtypes import schema, Schema, Annotation, Immutable, type_check
+from madtypes import json_schema, Schema, Annotation, Immutable, type_check
 import pytest
 import json
 
@@ -67,40 +67,43 @@ def test_set():
         a.gender.male = "foo"
 
 
-def test_int_schema():
-    assert schema(int) == {"type": "integer"}
+def test_int_json_schema():
+    assert json_schema(int) == {"type": "integer"}
 
 
-def test_array_schema():
-    assert schema(list[int]) == {"type": "array", "items": {"type": "integer"}}
+def test_array_json_schema():
+    assert json_schema(list[int]) == {
+        "type": "array",
+        "items": {"type": "integer"},
+    }
 
 
-def test_tuple_schema():
-    assert schema(tuple[int, int]) == {
+def test_tuple_json_schema():
+    assert json_schema(tuple[int, int]) == {
         "type": "array",
         "items": [{"type": "integer"}, {"type": "integer"}],
     }
 
 
-def test_object_schema():
+def test_object_json_schema():
     class Item(Schema):
         name: str
 
-    assert schema(Item) == {
+    assert json_schema(Item) == {
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     }
 
 
-def test_array_of_object_schema():
+def test_array_of_object_json_schema():
     class Item(Schema):
         name: str
 
     class Basket(Schema):
         items: list[Item]
 
-    schem = schema(Basket)
+    schem = json_schema(Basket)
     print(schem)
     assert schem == {
         "type": "object",
@@ -118,14 +121,14 @@ def test_array_of_object_schema():
     }
 
 
-def test_tuple_of_object_schema():
+def test_tuple_of_object_json_schema():
     class Item(Schema):
         name: str
 
     class Basket(Schema):
         some_items: tuple[Item, Item]
 
-    schem = schema(Basket)
+    schem = json_schema(Basket)
     print(schem)
     assert schem == {
         "type": "object",
@@ -150,9 +153,9 @@ def test_tuple_of_object_schema():
     }
 
 
-def test_object_with_object_schema():
-    print(schema(Item))
-    assert schema(Item) == {
+def test_object_with_object_json_schema():
+    print(json_schema(Item))
+    assert json_schema(Item) == {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
@@ -174,7 +177,7 @@ class PrimitiveArray(Schema):
 
 
 def test_annotation_array():
-    assert schema(PrimitiveArray) == {
+    assert json_schema(PrimitiveArray) == {
         "type": "object",
         "properties": {
             "items": {"type": "array", "items": {"type": "string"}}
@@ -193,7 +196,7 @@ class PrimitiveDescriptedArray(Schema):
 
 
 def test_descriptive_primitive_array():
-    result = schema(PrimitiveDescriptedArray)
+    result = json_schema(PrimitiveDescriptedArray)
     print(result)
     assert result == {
         "type": "object",
@@ -217,7 +220,7 @@ class ObjectArray(Schema):
 
 
 def test_object_array():
-    result = schema(ObjectArray)
+    result = json_schema(ObjectArray)
     print(result)
     assert result == {
         "type": "object",
@@ -254,7 +257,7 @@ class ObjectDescriptedArray(Schema):
 
 
 def test_descriptive_object_array():
-    result = schema(ObjectDescriptedArray)
+    result = json_schema(ObjectDescriptedArray)
     print(result)
     assert result == {
         "type": "object",
@@ -282,8 +285,8 @@ class PrimitiveTuple(Schema):
     tupled: tuple[int, str]
 
 
-def test_annotation_tuple_schema():
-    result = schema(PrimitiveTuple)
+def test_annotation_tuple_json_schema():
+    result = json_schema(PrimitiveTuple)
     print(result)
     assert result == {
         "type": "object",
@@ -334,7 +337,7 @@ def test_schemas_expect_types():
         value: "str"
 
     with pytest.raises(SyntaxError):
-        schema(Item)
+        json_schema(Item)
 
 
 def test_immutable():
@@ -379,12 +382,12 @@ def test_custom_method():
     assert SomeClass(name="foo").method() == "foo"
 
 
-def test_optional_json_schema():
+def test_optional_json_json_schema():
     class SomeClassWithOptional(Schema):
         name: Optional[str]
 
     SomeClassWithOptional()
-    schem = schema(SomeClassWithOptional)
+    schem = json_schema(SomeClassWithOptional)
     assert schem == {
         "type": "object",
         "properties": {"name": {"type": "string"}},
@@ -396,7 +399,7 @@ def test_optional_json_schema_with_array():
         elements: Optional[list[int]]
 
     SomeClassWithOptional()
-    schem = schema(SomeClassWithOptional)
+    schem = json_schema(SomeClassWithOptional)
     assert schem == {
         "type": "object",
         "properties": {
@@ -456,7 +459,7 @@ def test_descripted_list_object_value_set():
         DescriptedFoo(name=2)
 
 
-def test_descripted_json_schema():
+def test_descripted_json_json_schema():
     class DescriptedString(str, metaclass=Annotation):
         description = "Some description"
         annotation = str
@@ -464,8 +467,8 @@ def test_descripted_json_schema():
     class DescriptedItem(Schema):
         descripted: DescriptedString
 
-    print(schema(DescriptedItem))
-    assert schema(DescriptedItem) == {
+    print(json_schema(DescriptedItem))
+    assert json_schema(DescriptedItem) == {
         "type": "object",
         "properties": {
             "descripted": {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -475,3 +475,25 @@ def test_descripted_json_schema():
         },
         "required": ["descripted"],
     }
+
+
+def test_object_validation():
+    class Item(Schema):
+        title: Optional[str]
+        content: Optional[str]
+
+        def is_valid(self, **kwargs):
+            """title is mandatory if content is absent"""
+            return (
+                False
+                if not kwargs.get("content", None)
+                and not kwargs.get("title", None)
+                else True
+            )
+
+    Item(
+        title="foo"
+    )  # we should be able to create with only one of title or content
+    Item(content="foo")
+    with pytest.raises(TypeError):
+        Item()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from madtypes import schema, Schema, Annotation, Immutable
+from madtypes import schema, Schema, Annotation, Immutable, type_check
 import pytest
 import json
 
@@ -497,3 +497,27 @@ def test_object_validation():
     Item(content="foo")
     with pytest.raises(TypeError):
         Item()
+
+
+def test_set_set():
+    class Basket(Schema):
+        content: set[int]
+
+    Basket(content={1, 2, 3})
+
+
+def test_type_check_primitive():
+    assert type_check(1, int)
+
+
+def test_type_check_list_of_primitive():
+    assert type_check([1, 2], list[int])
+
+
+def test_type_check_set_of_primitive():
+    assert type_check({1}, set[int])
+
+
+def test_type_check_optional_primitive():
+    assert type_check(1, Optional[int])
+    assert type_check("foo", Optional[int]) == False

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -535,7 +535,7 @@ def test_pattern_definition_with_incorect_type():
         PhoneNumber(2)
 
 
-def test_pattern_definition():
+def test_pattern_definition_allows_normal_usage():
     class PhoneNumber(str, metaclass=Annotation):
         annotation = str
         pattern = r"\d{3}-\d{3}-\d{4}"  # Regex pattern to match a phone number in the format XXX-XXX-XXXX


### PR DESCRIPTION
changes:
- :new: `is_valid` method is used on Schema class to allow validation that is dependent on multiple fields
-  fix: "Subscripted generics cannot be used with class and instance checks"
- `is_value_compatible_with_annotation` has been renamed `type_check`
- Schema uses `type_check` whenever in should apply type checking
- tests for `type_check` (list, set, primitives)
- fix: type_check when used with `set` or `Optional`
- `schema` function has been renamed `json_schema`
- :new: `pattern` attribute on `Annotation` can be used to define regex validation
- setting a `pattern` attribute on an Annotation that is not a string or a byte will raise a `SyntaxError`
- Instantiating an Annotated item that has a pattern with a wrong value raise a `TypeError`
- `pattern` attribute is used by `json_schema`