### PR TITLE
Multiple inheritance

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,6 @@ name: Test
 on:
   push:
     branches: '**'
-    paths:
-      - 'madtypes/__init__.py'
-      - 'tests/test_schema.py'
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.11", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.pyc
+.coverage
+build
+dist
+madtypes.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # madtypes
-- 💢 Python class typing that raise TypeError at runtime
+- 💢 Python typing that raise TypeError at runtime
 - 📖 Render to dict or json
-- 🌐 [Json-Schema](https://json-schema.org/)
+- 🌐 Generate [Json-Schema](https://json-schema.org/)
+- 💪 [Type hints cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
 
 ```python
 from madtypes import Schema

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ assert json_schema(DescriptedItem) == {
 Regex can be defined on an Annotated type using the `pattern` attribute.
 
 :warning: be careful to respect the json-schema [specifications](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html) when using `json_schema`
-It this moment this is not checked and will render an invalid `json-schema`.
+At the moment it is not checked nor tested, and will probably render an invalid `json-schema` without warning nor error
 
 ```python
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ b = Foo(age=2, **e) # create a copy with changes
 
 [![Test](https://github.com/6r17/madtypes/actions/workflows/test.yaml/badge.svg)](./tests/test_schema.py)
 [![pypi](https://img.shields.io/pypi/v/madtypes)](https://pypi.org/project/madtypes/)
-![python: >3.9](https://img.shields.io/badge/python-%3E3.9-informational)
+![python: >3.10](https://img.shields.io/badge/python-%3E3.9-informational)
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ b = Foo(age=2, **e) # create a copy with changes
 
 [![Test](https://github.com/6r17/madtypes/actions/workflows/test.yaml/badge.svg)](./tests/test_schema.py)
 [![pypi](https://img.shields.io/pypi/v/madtypes)](https://pypi.org/project/madtypes/)
-![python: >3.10](https://img.shields.io/badge/python-%3E3.9-informational)
+![python: >3.10](https://img.shields.io/badge/python-%3E3.10-informational)
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class SomeDescriptedAttribute(str, metaclass=Annotation):
     description = "Some description"
 ```
 
-using json_schema` on `SomeDescription` will include the description attribute
+using `json_schema` on `SomeDescription` will include the description attribute
 
 ```python
 class DescriptedString(str, metaclass=Annotation):

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ class ItemWithOptional(Schema):
 
 ItemWithOptional() # ok
 ```
-  
+ 
 - ### json-schema
   
 ```python
@@ -171,6 +171,45 @@ def test_object_validation():
         Item()
 
 
+
+```
+
+
+### Multiple inheritance
+
+Sometimes technical contraints should not be rendered publicly, and you still want
+to use the existing class definitions.
+
+For instance one of those occurances is multiple objects that have different
+realities in the code, but have the same buisness organisation.
+
+Instead of having multiple keys pointing to each object, we would prefer to have a unique
+item with fields from both classes.
+
+In that occurance we can use multiple inheritance to define a class by combining
+existing definitions.
+
+```python
+
+
+def test_multiple_inheritance_json_schema():
+    class Foo(Schema):
+        foo: str
+
+    class Bar(Schema):
+        bar: str
+
+    class FooBar(Foo, Bar):
+        pass
+
+    assert len(FooBar.get_fields()) == 2
+    schema = json_schema(FooBar)
+    print(schema)
+    assert schema == {
+        "type": "object",
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
+        "required": ["foo", "bar"],
+    }
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ def test_enum():
 ```
 
 - ### 🔥 Annotation attributes
-It is possible to use the `Annotation` metaclass to add type-check to a class definition.
+It is possible to use the `Annotation` metaclass customize a type.
 
 ```python
 class SomeStringAttribute(str, metaclass=Annotation):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="madtypes",
-    version="0.0.5",
+    version="0.0.6",
     author="6r17",
     author_email="patrick.borowy@proton.me",
     description="Python typing that raise TypeError at runtime",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url="https://github.com/6r17/madtypes",
     packages=find_packages(include=["madtypes"]),
     keywords=["typing", "json", "json-schema"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
- fix: Multiple Inheritance
- fix: Set
- fix: Enum
- required python version bumped to 3.10 because class do not contain __annotation__ in python3.9