### PR TITLE
Field substraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,19 @@ It is possible to dynamicly remove a field from a class using the `subtract_fiel
 
 ```python
 
+def test_class_field_substraction():
+    class Item(Schema):
+        name: str
+        age: int
+
+    ageLessItem = subtract_fields("age")(Item)
+    # we can dynamicly create a new class by substracting fields from it
+    assert len(ageLessItem.get_fields()) == 1
+    with pytest.raises(TypeError):
+        ageLessItem(name="foo", age=2)
+    ageLessItem(name="foo")
+    with pytest.raises(AttributeError):
+        assert getattr(Item, "age")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ def test_object_validation():
 
 ```
 
-
 ### Multiple inheritance
 
 Sometimes technical contraints should not be rendered publicly, and you still want
@@ -256,6 +255,15 @@ def test_multiple_inheritance_json_schema():
         "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
         "required": ["foo", "bar"],
     }
+
+```
+
+- ### Dynamicly remove a field
+
+It is possible to dynamicly remove a field from a class using the `subtract_fields(args: tuple[str])` decorator which will return a new class without the provided fields.
+
+```python
+
 
 ```
 

--- a/madtypes/__init__.py
+++ b/madtypes/__init__.py
@@ -85,7 +85,7 @@ def subtract_fields(*fields):
             if field in new_annotations:
                 del new_annotations[field]
             if field in new_cls_dict:
-                del new_cls_dict[field]
+                del new_cls_dict[field]  # pragma: no cover (tested by getattr)
 
         new_cls_dict["__annotations__"] = new_annotations
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="madtypes",
-    version="0.0.6",
+    version="0.0.7",
     author="6r17",
     author_email="patrick.borowy@proton.me",
     description="Python typing that raise TypeError at runtime",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -680,3 +680,18 @@ def test_class_field_substraction():
     ageLessItem(name="foo")
     with pytest.raises(AttributeError):
         assert getattr(Item, "age")
+
+
+def test_json_schema_after_substraction():
+    class Item(Schema):
+        name: str
+        age: int
+
+    ageLessItem = subtract_fields("age")(Item)
+    schema = json_schema(ageLessItem)
+    print(schema)
+    assert schema == {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -584,26 +584,6 @@ def test_pattern_is_rendered_in_json_schema():
     }
 
 
-def test_multiple_inheritance_json_schema():
-    class Foo(Schema):
-        foo: str
-
-    class Bar(Schema):
-        bar: str
-
-    class FooBar(Foo, Bar):
-        pass
-
-    assert len(FooBar.get_fields()) == 2
-    schema = json_schema(FooBar)
-    print(schema)
-    assert schema == {
-        "type": "object",
-        "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
-        "required": ["foo", "bar"],
-    }
-
-
 def test_list_json_schema():
     class Foo(Schema):
         my_set: list[int]
@@ -695,3 +675,52 @@ def test_json_schema_after_substraction():
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     }
+
+
+def test_multiple_inheritance_json_schema():
+    class Foo(Schema):
+        foo: str
+
+    class Bar(Schema):
+        bar: str
+
+    class FooBar(Foo, Bar):
+        pass
+
+    assert len(FooBar.get_fields()) == 2
+    schema = json_schema(FooBar)
+    print(schema)
+    assert schema == {
+        "type": "object",
+        "properties": {"foo": {"type": "string"}, "bar": {"type": "string"}},
+        "required": ["foo", "bar"],
+    }
+
+
+def test_multiple_inheritance_integrity():
+    class Foo(Schema):
+        foo: str
+
+    class Bar(Schema):
+        bar: str
+
+    class FooBar(Foo, Bar):
+        pass
+
+    FooBar(foo="foo", bar="bar")
+
+
+def test_json_schema_after_edition_and_multiple_inheritance():
+    class Person(Schema):
+        name: str
+        age: int
+
+    class Contact(Schema):
+        phone: str
+
+    agelessPerson = subtract_fields("age")(Person)
+
+    class NamedContact(agelessPerson, Contact):
+        pass
+
+    NamedContact(name="foo", phone="baz")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,13 @@
 from enum import Enum
 from typing import Optional
-from madtypes import json_schema, Schema, Annotation, Immutable, type_check
+from madtypes import (
+    json_schema,
+    Schema,
+    Annotation,
+    Immutable,
+    type_check,
+    subtract_fields,
+)
 import pytest
 import json
 
@@ -658,3 +665,16 @@ def test_enum():
     Item(key=SomeEnum.FOO)
     with pytest.raises(TypeError):
         Item(key="Foo")
+
+
+def test_class_field_substraction():
+    class Item(Schema):
+        name: str
+        age: int
+
+    ageLessItem = subtract_fields("age")(Item)
+    # we can dynamicly create a new class by substracting fields from it
+    assert len(ageLessItem.get_fields()) == 1
+    with pytest.raises(TypeError):
+        ageLessItem(name="foo", age=2)
+    ageLessItem(name="foo")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -678,3 +678,5 @@ def test_class_field_substraction():
     with pytest.raises(TypeError):
         ageLessItem(name="foo", age=2)
     ageLessItem(name="foo")
+    with pytest.raises(AttributeError):
+        assert getattr(Item, "age")


### PR DESCRIPTION
- :new: `subtract_fields` (*args: tuple[str])(class) allow to remove fields from a class. It can be used to dynamically create schemas based on existing work without creating multiple sources of truth.
- :hammer_and_wrench: extra parameter should raise a TypeError
- :hammer_and_wrench: type check for multi-inherited objects